### PR TITLE
Task: Improve retrieval of AWS credentials PLA-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ This will permit you to use the S3 AWS service, should you provide a JSON file i
 The file should have the following name so that plato can recognize it:
 *aws_credentials.json*
 
+The AWS S3 credentials JSON file should also have the following format:
+```json
+{"aws_access_key_id": "AWS access key ID",
+"aws_secret_access_key":"AWS secret access key",
+"region_name":"Default region when creating new connections"}
+```
+*Note: These are the necessary properties for functionality. If any other properties are needed, you can click this [link](https://docs.aws.amazon.com/boto3/latest/reference/core/session.html#boto3.session.Session),
+which leads to the AWS documentation, in regard to session parameters.*
+
 Alternatively, you can use the GCS service following the same process. However, the JSON file for the GCS service will need a
 different name:
 *service_account_key.json*

--- a/README.md
+++ b/README.md
@@ -79,10 +79,13 @@ the directory where your templates are stored.
 
 e.g TEMPLATE_DIRECTORY_NAME=projects/templating
 
-Make sure the bucket is accessible by providing credentials to the service by
-storing the S3 AWS credentials in your DATA_DIR/aws/. Also, ensure that you have a credentials folder inside DATA_DIR.
-This will permit you to use the GCS service, as an alternative to S3 AWS, should you provide a JSON file inside 
-the folder with the GCS credentials. This JSON file has to have a specific name so that plato can recognize it: 
+Ensure that you have a credentials folder inside DATA_DIR.
+This will permit you to use the S3 AWS service, should you provide a JSON file inside the folder with the S3 credentials.
+The file should have the following name so that plato can recognize it:
+*aws_credentials.json*
+
+Alternatively, you can use the GCS service following the same process. However, the JSON file for the GCS service will need a
+different name:
 *service_account_key.json*
 
 #### Database

--- a/app/file_storage.py
+++ b/app/file_storage.py
@@ -137,7 +137,8 @@ class S3FileStorage(PlatoFileStorage):
             key_content_mapping[new_key] = content
         return key_content_mapping
 
-    def get_aws_credentials(self, path_to_file: str) -> Any:
+    @staticmethod
+    def get_aws_credentials(path_to_file: str) -> Any:
         with open(f"{path_to_file}") as aws_credentials_file:
             return json.loads(aws_credentials_file.read())
 

--- a/app/file_storage.py
+++ b/app/file_storage.py
@@ -113,8 +113,7 @@ class S3FileStorage(PlatoFileStorage):
     def __init__(self, data_directory: str, bucket_name: str):
         super().__init__(data_directory)
         self.bucket_name = bucket_name
-        with open(f"{get_settings().CREDENTIALS_DIR}/aws_credentials.json") as aws_credentials_file:
-            self.aws_credentials_dict = json.loads(aws_credentials_file.read())
+        self.aws_credentials_dict = self.get_aws_credentials(f"{get_settings().CREDENTIALS_DIR}/aws_credentials.json")
 
     def get_file(self, path: str, template_directory: str) -> Dict[str, Any]:
         """
@@ -137,6 +136,10 @@ class S3FileStorage(PlatoFileStorage):
             new_key = key[len(template_directory):]
             key_content_mapping[new_key] = content
         return key_content_mapping
+
+    def get_aws_credentials(self, path_to_file: str) -> Any:
+        with open(f"{path_to_file}") as aws_credentials_file:
+            return json.loads(aws_credentials_file.read())
 
 
 class GCSFileStorage(PlatoFileStorage):

--- a/app/file_storage.py
+++ b/app/file_storage.py
@@ -138,9 +138,16 @@ class S3FileStorage(PlatoFileStorage):
         return key_content_mapping
 
     @staticmethod
-    def get_aws_credentials(path_to_file: str) -> Any:
-        with open(f"{path_to_file}") as aws_credentials_file:
-            return json.loads(aws_credentials_file.read())
+    def get_aws_credentials(path_to_file: str) -> Dict[str, Any]:
+        try:
+            with open(f"{path_to_file}", encoding="utf-8") as aws_credentials_file:
+                return json.loads(aws_credentials_file.read())
+        except FileNotFoundError as exc:
+            raise FileStorageError(f"AWS credentials file not found at '{path_to_file}'. "
+                "Expected a UTF-8 encoded JSON file containing AWS credential key/value pairs.") from exc
+        except json.JSONDecodeError as exc:
+            raise FileStorageError(f"Invalid JSON in AWS credentials file at '{path_to_file}'. "
+                "Expected a UTF-8 encoded JSON object containing AWS credential key/value pairs.") from exc
 
 
 class GCSFileStorage(PlatoFileStorage):

--- a/app/file_storage.py
+++ b/app/file_storage.py
@@ -1,3 +1,4 @@
+import json
 import pathlib
 from abc import ABC
 from enum import Enum
@@ -112,6 +113,8 @@ class S3FileStorage(PlatoFileStorage):
     def __init__(self, data_directory: str, bucket_name: str):
         super().__init__(data_directory)
         self.bucket_name = bucket_name
+        with open(f"{get_settings().CREDENTIALS_DIR}/aws_credentials.json") as aws_credentials_file:
+            self.aws_credentials_dict = json.loads(aws_credentials_file.read())
 
     def get_file(self, path: str, template_directory: str) -> Dict[str, Any]:
         """
@@ -126,7 +129,7 @@ class S3FileStorage(PlatoFileStorage):
          A dictionary with key as file's relative location on s3-bucket and value as file's content
         """
         key_content_mapping: dict = {}
-        for key, content in s3.iter_bucket(bucket_name=self.bucket_name, prefix=path):
+        for key, content in s3.iter_bucket(bucket_name=self.bucket_name, prefix=path, **self.aws_credentials_dict):
             if key[-1] == '/' or not content:
                 # Is a directory
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -47,24 +47,31 @@ def _setup_test_db(database_uri):
 
 @pytest.fixture(scope='class')
 def fastapi_client_s3_storage(db):
-    @asynccontextmanager
-    async def mock_lifespan(app):
-        with tempfile.TemporaryDirectory() as file_dir:
-            app.state.file_storage = S3FileStorage(file_dir, settings.BUCKET_NAME)
-            app.state.jinja_env = JinjaEnv(
-                loader=DictLoader({}),
-                autoescape=select_autoescape(["html", "xml"]),
-                auto_reload=True
-            )
-            current_folder = Path(__file__).resolve().parent
-            app.state.template_static_directory = str(current_folder / "resources/static")
-            yield
+    mock_aws_credentials_data = """\
+    {"aws_access_key_id": "test_aws_key",
+     "aws_secret_access_key": "test_secret_key",
+     "region_name": "test_region"}
+     """
+    mock_aws_open = mock_open(read_data=mock_aws_credentials_data)
+    with patch("builtins.open", mock_aws_open):
+        @asynccontextmanager
+        async def mock_lifespan(app):
+            with tempfile.TemporaryDirectory() as file_dir:
+                app.state.file_storage = S3FileStorage(file_dir, settings.BUCKET_NAME)
+                app.state.jinja_env = JinjaEnv(
+                    loader=DictLoader({}),
+                    autoescape=select_autoescape(["html", "xml"]),
+                    auto_reload=True
+                )
+                current_folder = Path(__file__).resolve().parent
+                app.state.template_static_directory = str(current_folder / "resources/static")
+                yield
 
-    app.dependency_overrides[get_db] = lambda: db
-    app.router.lifespan_context = mock_lifespan
+        app.dependency_overrides[get_db] = lambda: db
+        app.router.lifespan_context = mock_lifespan
 
-    with TestClient(app) as client:
-        yield client
+        with TestClient(app) as client:
+            yield client
 
 
 @pytest.fixture(scope='class')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 from unittest import mock
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -49,7 +49,7 @@ def _setup_test_db(database_uri):
 def fastapi_client_s3_storage(db):
     @asynccontextmanager
     async def mock_lifespan(app):
-        with tempfile.TemporaryDirectory() as file_dir, patch("app.file_storage.S3FileStorage.get_aws_credentials") as mock_get_aws_credentials:
+        with tempfile.TemporaryDirectory() as file_dir, mock.patch("app.file_storage.S3FileStorage.get_aws_credentials") as mock_get_aws_credentials:
             mock_get_aws_credentials.return_value = {"aws_access_key_id": "test_aws_key",
                                                      "aws_secret_access_key": "test_secret_key",
                                                      "region_name": "test_region"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,31 +47,27 @@ def _setup_test_db(database_uri):
 
 @pytest.fixture(scope='class')
 def fastapi_client_s3_storage(db):
-    mock_aws_credentials_data = """\
-    {"aws_access_key_id": "test_aws_key",
-     "aws_secret_access_key": "test_secret_key",
-     "region_name": "test_region"}
-     """
-    mock_aws_open = mock_open(read_data=mock_aws_credentials_data)
-    with patch("builtins.open", mock_aws_open):
-        @asynccontextmanager
-        async def mock_lifespan(app):
-            with tempfile.TemporaryDirectory() as file_dir:
-                app.state.file_storage = S3FileStorage(file_dir, settings.BUCKET_NAME)
-                app.state.jinja_env = JinjaEnv(
-                    loader=DictLoader({}),
-                    autoescape=select_autoescape(["html", "xml"]),
-                    auto_reload=True
-                )
-                current_folder = Path(__file__).resolve().parent
-                app.state.template_static_directory = str(current_folder / "resources/static")
-                yield
+    @asynccontextmanager
+    async def mock_lifespan(app):
+        with tempfile.TemporaryDirectory() as file_dir, patch("app.file_storage.S3FileStorage.get_aws_credentials") as mock_get_aws_credentials:
+            mock_get_aws_credentials.return_value = {"aws_access_key_id": "test_aws_key",
+                                                     "aws_secret_access_key": "test_secret_key",
+                                                     "region_name": "test_region"}
+            app.state.file_storage = S3FileStorage(file_dir, settings.BUCKET_NAME)
+            app.state.jinja_env = JinjaEnv(
+                loader=DictLoader({}),
+                autoescape=select_autoescape(["html", "xml"]),
+                auto_reload=True
+            )
+            current_folder = Path(__file__).resolve().parent
+            app.state.template_static_directory = str(current_folder / "resources/static")
+            yield
 
-        app.dependency_overrides[get_db] = lambda: db
-        app.router.lifespan_context = mock_lifespan
+    app.dependency_overrides[get_db] = lambda: db
+    app.router.lifespan_context = mock_lifespan
 
-        with TestClient(app) as client:
-            yield client
+    with TestClient(app) as client:
+        yield client
 
 
 @pytest.fixture(scope='class')

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -131,8 +131,8 @@ class TestFileStorage:
         template_files_dict = s3_file_storage.get_file(f"{BASE_DIR}/templates", BASE_DIR)
         assert template_files_dict == {"/templates/0/0": b'file content'}
 
-        calls = [call(bucket_name="test_template_bucket", prefix=f"{BASE_DIR}/static"),
-                 call(bucket_name="test_template_bucket", prefix=f"{BASE_DIR}/templates")]
+        calls = [call(bucket_name="test_template_bucket", prefix=f"{BASE_DIR}/static", **s3_file_storage.aws_credentials_dict),
+                 call(bucket_name="test_template_bucket", prefix=f"{BASE_DIR}/templates", **s3_file_storage.aws_credentials_dict)]
         mock_iter_bucket.assert_has_calls(calls, any_order=True)
         # when debugging, the mocked iterator calls __len__() for some reason. this is why any_order is set to True
         # to, at least, guarantee that the calls we want actually are present in mock_iter_bucket.mock_calls

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -5,7 +5,7 @@ from unittest import mock
 from unittest.mock import call, MagicMock, mock_open
 
 import pytest
-from app.file_storage import S3FileStorage, NoIndexTemplateFound
+from app.file_storage import S3FileStorage, NoIndexTemplateFound, FileStorageError
 from app.models import Template
 from google.cloud.storage import Blob
 from sqlalchemy.orm import Session
@@ -67,11 +67,28 @@ class TestFileStorage:
         mock_aws_open = mock_open(read_data=mock_aws_credentials_data)
 
         with mock.patch("builtins.open", mock_aws_open):
-            result = S3FileStorage.get_aws_credentials(f"path_to_aws_credentials/")
+            result = S3FileStorage.get_aws_credentials(f"path_to_aws_credentials/aws_credentials.json")
 
         assert result == {"aws_access_key_id": "test_aws_key_unit_test",
                           "aws_secret_access_key": "test_secret_key_unit_test",
                           "region_name": "test_region_unit_test"}
+
+    def test_get_aws_credentials_no_file_found(self):
+        with pytest.raises(FileStorageError):
+            S3FileStorage.get_aws_credentials(f"path_to_aws_credentials/aws_credentials.json")
+
+    def test_get_aws_credentials_invalid_json_error(self):
+        mock_aws_credentials_data = """\
+            {"aws_access_key_id": "test_aws_key_unit_test",
+             "aws_secret_access_key": "test_secret_key_unit_test",
+             "region_name": "test_region_unit_test",
+             invalid_key: invalid_value}
+             """
+        mock_aws_open = mock_open(read_data=mock_aws_credentials_data)
+
+        with pytest.raises(FileStorageError):
+            with mock.patch("builtins.open", mock_aws_open):
+                S3FileStorage.get_aws_credentials(f"path_to_aws_credentials/aws_credentials.json")
 
     @pytest.mark.usefixtures("populate_db")
     @mock.patch.object(S3FileStorage, "get_file")

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -2,7 +2,7 @@ import pathlib
 from tempfile import TemporaryDirectory
 
 from unittest import mock
-from unittest.mock import call, MagicMock
+from unittest.mock import call, MagicMock, mock_open
 
 import pytest
 from app.file_storage import S3FileStorage, NoIndexTemplateFound
@@ -57,6 +57,21 @@ class TestFileStorage:
             assert pathlib.Path(static_file_1).is_file()
             assert pathlib.Path(static_file_2).is_file()
             assert pathlib.Path(template_file_1).is_file()
+
+    def test_get_aws_credentials(self):
+        mock_aws_credentials_data = """\
+            {"aws_access_key_id": "test_aws_key_unit_test",
+             "aws_secret_access_key": "test_secret_key_unit_test",
+             "region_name": "test_region_unit_test"}
+             """
+        mock_aws_open = mock_open(read_data=mock_aws_credentials_data)
+
+        with mock.patch("builtins.open", mock_aws_open):
+            result = S3FileStorage.get_aws_credentials(f"path_to_aws_credentials/")
+
+        assert result == {"aws_access_key_id": "test_aws_key_unit_test",
+                          "aws_secret_access_key": "test_secret_key_unit_test",
+                          "region_name": "test_region_unit_test"}
 
     @pytest.mark.usefixtures("populate_db")
     @mock.patch.object(S3FileStorage, "get_file")
@@ -136,14 +151,6 @@ class TestFileStorage:
         mock_iter_bucket.assert_has_calls(calls, any_order=True)
         # when debugging, the mocked iterator calls __len__() for some reason. this is why any_order is set to True
         # to, at least, guarantee that the calls we want actually are present in mock_iter_bucket.mock_calls
-
-    @mock.patch("app.file_storage.S3FileStorage.get_aws_credentials")
-    def test_get_aws_credentials(self, mock_get_aws_credentials, fastapi_client_s3_storage: TestClient):
-        mock_get_aws_credentials.return_value = {"aws_access_key_id": "test_aws_key_unit_test",
-                                                 "aws_secret_access_key": "test_secret_key_unit_test",
-                                                 "region_name": "test_region_unit_test"}
-        s3_file_storage = fastapi_client_s3_storage.app.state.file_storage
-        assert s3_file_storage.get_aws_credentials(f"path_to_aws_credentials/") == mock_get_aws_credentials.return_value
 
 
     def test_file_storage_get_file_gcs(self, fastapi_client_gcs_storage: TestClient):

--- a/tests/test_file_storage.py
+++ b/tests/test_file_storage.py
@@ -137,6 +137,15 @@ class TestFileStorage:
         # when debugging, the mocked iterator calls __len__() for some reason. this is why any_order is set to True
         # to, at least, guarantee that the calls we want actually are present in mock_iter_bucket.mock_calls
 
+    @mock.patch("app.file_storage.S3FileStorage.get_aws_credentials")
+    def test_get_aws_credentials(self, mock_get_aws_credentials, fastapi_client_s3_storage: TestClient):
+        mock_get_aws_credentials.return_value = {"aws_access_key_id": "test_aws_key_unit_test",
+                                                 "aws_secret_access_key": "test_secret_key_unit_test",
+                                                 "region_name": "test_region_unit_test"}
+        s3_file_storage = fastapi_client_s3_storage.app.state.file_storage
+        assert s3_file_storage.get_aws_credentials(f"path_to_aws_credentials/") == mock_get_aws_credentials.return_value
+
+
     def test_file_storage_get_file_gcs(self, fastapi_client_gcs_storage: TestClient):
         gcs_file_storage = fastapi_client_gcs_storage.app.state.file_storage
         template_blob = MagicMock(Blob)
@@ -161,3 +170,4 @@ class TestFileStorage:
         calls = [call(prefix=f"{BASE_DIR}/static"),
                  call(prefix=f"{BASE_DIR}/templates")]
         bucket.list_blobs.assert_has_calls(calls)
+


### PR DESCRIPTION
This PR's objective is to improve the way plato retrieves the AWS credentials from previously being defaulted to retrieve them from the home/.aws folder to retrieve them from a proper .json file located in the credentials directory.